### PR TITLE
keep-fullname

### DIFF
--- a/lib/aws_codegen/docstring.ex
+++ b/lib/aws_codegen/docstring.ex
@@ -20,7 +20,6 @@ defmodule AWS.CodeGen.Docstring do
   """
   def html_to_markdown(text) do
     convert_links(text)
-    |> convert_fullname
     |> String.replace("<a>", "`")
     |> String.replace("</a>", "`")
     |> String.replace("<b>", "**")
@@ -28,7 +27,7 @@ defmodule AWS.CodeGen.Docstring do
     |> String.replace("<code>", "`")
     |> String.replace("</code>", "`")
     |> String.replace("<fullname>", "")
-    |> String.replace("</fullname>", "")
+    |> String.replace("</fullname>", "\n\n")
     |> String.replace("<i>", "*")
     |> String.replace("</i>", "*")
     |> String.replace("<p>", "")
@@ -61,10 +60,6 @@ defmodule AWS.CodeGen.Docstring do
   defp convert_links(text) do
     Regex.replace(~r{<a href="(.+?)">(.+?)</a>}, text, "[\\2](\\1)",
                   global: true)
-  end
-
-  defp convert_fullname(text) do
-    Regex.replace(~r{<fullname>(.+?)</fullname>}, text, "", global: true)
   end
 
   defp break_line(text, max_length) do

--- a/test/aws_codegen/docstring_test.exs
+++ b/test/aws_codegen/docstring_test.exs
@@ -16,9 +16,9 @@ defmodule AWS.CodeGen.DocstringTest do
     assert "Hello, `world`!" == Docstring.html_to_markdown(text)
   end
 
-  test "html_to_markdown/1 strips <fullname> tags and text" do
+  test "html_to_markdown/1 strips <fullname> tags and renders text as a paragraph" do
     text = "<fullname>Hello, world!</fullname>"
-    assert "" == Docstring.html_to_markdown(text)
+    assert "Hello, world!\n\n" == Docstring.html_to_markdown(text)
   end
 
   test "html_to_markdown/1 converts <p> tags to newline-separated paragraphs" do


### PR DESCRIPTION
Rework handling of `fullname` tags to create a simple top-level name
for each module (that has a full name defined in the JSON).
