### PR TITLE
convert-important-tag-to-bold

### DIFF
--- a/lib/aws_codegen/docstring.ex
+++ b/lib/aws_codegen/docstring.ex
@@ -32,6 +32,8 @@ defmodule AWS.CodeGen.Docstring do
     |> String.replace("</i>", "*")
     |> String.replace("<important>", "**")
     |> String.replace("</important>", "**")
+    |> String.replace("<note>", "*")
+    |> String.replace("</note>", "*")
     |> String.replace("<p>", "")
     |> String.replace("</p>", "\n\n")
   end

--- a/lib/aws_codegen/docstring.ex
+++ b/lib/aws_codegen/docstring.ex
@@ -30,6 +30,8 @@ defmodule AWS.CodeGen.Docstring do
     |> String.replace("</fullname>", "\n\n")
     |> String.replace("<i>", "*")
     |> String.replace("</i>", "*")
+    |> String.replace("<important>", "**")
+    |> String.replace("</important>", "**")
     |> String.replace("<p>", "")
     |> String.replace("</p>", "\n\n")
   end

--- a/test/aws_codegen/docstring_test.exs
+++ b/test/aws_codegen/docstring_test.exs
@@ -53,6 +53,11 @@ defmodule AWS.CodeGen.DocstringTest do
     assert "**Hello, world!**" == Docstring.html_to_markdown(text)
   end
 
+  test "html_to_markdown/1 replaces <important> tags with double-asterisks" do
+    text = "<important>Hello, world!</important>"
+    assert "**Hello, world!**" == Docstring.html_to_markdown(text)
+  end
+
   test "split_paragraphs/1 converts an empty paragraph to an empty list" do
     assert [] == Docstring.split_paragraphs("")
   end

--- a/test/aws_codegen/docstring_test.exs
+++ b/test/aws_codegen/docstring_test.exs
@@ -48,6 +48,11 @@ defmodule AWS.CodeGen.DocstringTest do
     assert "*Hello, world!*" == Docstring.html_to_markdown(text)
   end
 
+  test "html_to_markdown/1 replaces <note> tags with asterisks" do
+    text = "<note>Hello, world!</note>"
+    assert "*Hello, world!*" == Docstring.html_to_markdown(text)
+  end
+
   test "html_to_markdown/1 replaces <b> tags with double-asterisks" do
     text = "<b>Hello, world!</b>"
     assert "**Hello, world!**" == Docstring.html_to_markdown(text)


### PR DESCRIPTION
Convert `<important>` tags to bold Markdown and `<notes>` tags to
italics Markdown.
