### PR TITLE
Don't ask Poison to parse responses with no body.

### DIFF
--- a/priv/rest_json.ex.eex
+++ b/priv/rest_json.ex.eex
@@ -59,6 +59,8 @@ defmodule <%= context.module_name %> do
 
   defp perform_request(method, url, payload, headers, options, nil) do
     case HTTPoison.request(method, url, payload, headers, options) do
+      {:ok, response=%HTTPoison.Response{status_code: 200, body: ""}} ->
+        {:ok, response}
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
       {:ok, response=%HTTPoison.Response{status_code: 202, body: body}} ->


### PR DESCRIPTION
Some AWS responses are just a 200 with empty body. These changes prevent attempting to parse this empty body, which causes Poison to throw an exception.