### PR TITLE
Return the reason alongside the exception

### DIFF
--- a/priv/json.erl.eex
+++ b/priv/json.erl.eex
@@ -46,7 +46,8 @@ handle_response({ok, 200, ResponseHeaders, Client}) ->
     {ok, Result, {200, ResponseHeaders, Client}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {ok, Body} = hackney:body(Client),
-    Reason = maps:get(<<"__type">>, jsx:decode(Body, [return_maps])),
-    {error, Reason, {StatusCode, ResponseHeaders, Client}};
+    #{<<"__type">> := Exception,
+      <<"message">> := Reason} = jsx:decode(Body, [return_maps]),
+    {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.


### PR DESCRIPTION
This changes the code generator to return both the
`Reason` and the `Exception`, instead of only the
`Exception`. This is because `Reason` can often be
helpful to debug request issues.