### PR TITLE
Handle empty responses

### DIFF
--- a/priv/json.erl.eex
+++ b/priv/json.erl.eex
@@ -24,6 +24,13 @@
 %% Internal functions
 %%====================================================================
 
+-spec request(hackney:client(), binary(), map(), list()) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map() | undefined,
+    Error :: {binary(), binary()}.
+
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"<%= context.signing_name %>">>},
     Host = aws_util:binary_join([<<"<%= context.endpoint_prefix %>.">>,
@@ -41,9 +48,13 @@ request(Client, Action, Input, Options) ->
     handle_response(Response).
 
 handle_response({ok, 200, ResponseHeaders, Client}) ->
-    {ok, Body} = hackney:body(Client),
-    Result = jsx:decode(Body, [return_maps]),
-    {ok, Result, {200, ResponseHeaders, Client}};
+    case hackney:body(Client) of
+        {ok, <<>>} ->
+            {ok, undefined, {200, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = jsx:decode(Body, [return_maps]),
+            {ok, Result, {200, ResponseHeaders, Client}}
+    end;
 handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {ok, Body} = hackney:body(Client),
     #{<<"__type">> := Exception,

--- a/priv/json.ex.eex
+++ b/priv/json.ex.eex
@@ -13,6 +13,10 @@ defmodule <%= context.module_name %> do
     request(client, "<%= action.name %>", input, options)
   end
 <% end %>
+  @spec request(map(), binary(), map(), list()) ->
+    {:ok, Poison.Parser.t | nil, Poison.Response.t} |
+    {:error, Poison.Parser.t} |
+    {:error, HTTPoison.Error.t}
   defp request(client, action, input, options) do
     client = %{client | service: "<%= context.endpoint_prefix %>"}
     host = "<%= context.endpoint_prefix %>.#{client.region}.#{client.endpoint}"
@@ -23,6 +27,8 @@ defmodule <%= context.module_name %> do
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
     case HTTPoison.post(url, payload, headers, options) do
+      {:ok, response=%HTTPoison.Response{status_code: 200, body: ""}} ->
+        {:ok, nil, response}
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
       {:ok, _response=%HTTPoison.Response{body: body}} ->


### PR DESCRIPTION
Some AWS services including KMS may return empty responses, i.e., content length of zero. Both the erlang and elixir JSON parsers fail with an error on empty input. These errors crash the clients. This change handles empty responses. The result for empty responses in case of erlang is `undefined`, in case of elixir `nil`.

