### PR TITLE
fix-rest-json-trailing-slash

### DIFF
--- a/lib/aws_codegen/rest_json_service.ex
+++ b/lib/aws_codegen/rest_json_service.ex
@@ -33,7 +33,11 @@ defmodule AWS.CodeGen.RestJSONService do
         fn(parameter, acc) ->
           name = Enum.join([~S(#{), "URI.encode(", parameter.code_name, ")", ~S(})])
           String.replace(acc, "{#{parameter.name}}", "#{name}")
-        end)
+        end) |>
+      # FIXME(jkakar) This is only here because the invoke-async method
+      # defined for the Lambda API has an apparentyl spurious trailing slash
+      # in the JSON spec.
+      String.rstrip(?/)
     end
   end
 


### PR DESCRIPTION
Strip trailing slashes in generated URLs for REST-JSON services.