### PR TITLE
avoid-parsing-empty-body

### DIFF
--- a/priv/rest_json.ex.eex
+++ b/priv/rest_json.ex.eex
@@ -77,6 +77,8 @@ defmodule <%= context.module_name %> do
 
   defp perform_request(method, url, payload, headers, options, success_status_code) do
     case HTTPoison.request(method, url, payload, headers, options) do
+      {:ok, response=%HTTPoison.Response{status_code: ^success_status_code, body: ""}} ->
+        {:ok, nil, response}
       {:ok, response=%HTTPoison.Response{status_code: ^success_status_code, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
       {:ok, _response=%HTTPoison.Response{body: body}} ->


### PR DESCRIPTION
Handle empty bodies.  @HashNuke this is where I fixed the empty body issue in the code generator.