### PR TITLE
Support inconstant Kinesis API

### DIFF
--- a/priv/json.erl.eex
+++ b/priv/json.erl.eex
@@ -52,8 +52,9 @@ handle_response({ok, 200, ResponseHeaders, Client}) ->
     end;
 handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {ok, Body} = hackney:body(Client),
-    #{<<"__type">> := Exception,
-      <<"message">> := Reason} = jsx:decode(Body, [return_maps]),
+    Error = jsx:decode(Body, [return_maps]),
+    Exception = maps:get(<<"__type">>, Error, undefined),
+    Reason = maps:get(<<"message">>, Error, undefined),
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.

--- a/priv/json.ex.eex
+++ b/priv/json.ex.eex
@@ -32,8 +32,10 @@ defmodule <%= context.module_name %> do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
       {:ok, _response=%HTTPoison.Response{body: body}} ->
-        reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        error = Poison.Parser.parse!(body)
+        exception = error["__type"]
+        message = error["message"]
+        {:error, {exception, message}}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end


### PR DESCRIPTION
The Kinesis API does not fully adhere to the
specification and errors do not always come with
a `message`. This commit will work even if the API
is not adhering fully to the spec.