### PR TITLE
Remove trailing slash to fix API Gateway request

### DIFF
--- a/priv/rest_json.ex.eex
+++ b/priv/rest_json.ex.eex
@@ -98,7 +98,7 @@ defmodule <%= context.module_name %> do
   end
 
   defp get_url(host, url, %{:proto => proto, :port => port}) do
-    "#{proto}://#{host}:#{port}#{url}/"
+    "#{proto}://#{host}:#{port}#{url}"
   end
 
   defp encode_payload(input) do


### PR DESCRIPTION
When making API Gateway requests (specifically using `import_rest_api`) the String-to-Sign is incorrect because of this trailing slash in the Canonical Request. I'm not sure if this will have an impact on any other requests in the library, or if others are already not working because of this, but have confirmed it's fixed the `import_rest_api` request.