### PR TITLE
Fix URL parameters in generated API Gateway and IoT URLs

### DIFF
--- a/lib/aws_codegen/rest_json_service.ex
+++ b/lib/aws_codegen/rest_json_service.ex
@@ -32,7 +32,7 @@ defmodule AWS.CodeGen.RestJSONService do
       Enum.reduce(action.url_parameters, action.request_uri,
         fn(parameter, acc) ->
           name = Enum.join([~S(#{), "URI.encode(", parameter.code_name, ")", ~S(})])
-          String.replace(acc, "{#{parameter.name}}", "#{name}")
+          String.replace(acc, "{#{parameter.location_name}}", name)
         end) |>
       # FIXME(jkakar) This is only here because the invoke-async method
       # defined for the Lambda API has an apparentyl spurious trailing slash


### PR DESCRIPTION
This affects `lib/aws/api_gateway.ex` and `lib/aws/iot.ex` in generated Elixir code.

The encoded URL params were not being interpolated correctly because the camelcased `name` value was being used instead of the correctly snake cased `location_name` value.

After updating the aws-elixir source, there are many changes like this:

```diff
   def create_authorizer(client, rest_api_id, input, options \\ []) do
-    url = "/restapis/{restapi_id}/authorizers"
+    url = "/restapis/#{URI.encode(rest_api_id)}/authorizers"
     headers = []
     request(client, :post, url, headers, input, options, 201)
   end
```