### PR TITLE
Update eamark and ex_doc to latest versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: elixir
-otp_release:
-  - 17.4
+elixir: 1.4.1
+otp_release: 19.1

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule AWS.CodeGen.Mixfile do
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application
@@ -27,8 +27,8 @@ defmodule AWS.CodeGen.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:earmark, "~> 0.1.17", only: :dev},
-     {:ex_doc, "~> 0.7.3", only: :dev},
+    [{:earmark, "~> 1.1", only: :dev},
+     {:ex_doc, "~> 0.15.0", only: :dev},
      {:poison, "~> 1.4.0"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-%{"earmark": {:hex, :earmark, "0.1.17"},
-  "ex_doc": {:hex, :ex_doc, "0.7.3"},
-  "poison": {:hex, :poison, "1.4.0"}}
+%{"earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
+  "poison": {:hex, :poison, "1.4.0", "cd5afb9db7f0d19487572fa28185b6d4de647f14235746824e77b3139b79b725", [:mix], []}}


### PR DESCRIPTION
Hello @jkakar 

I finally found some time to work on your generator, and I hope to be able to add the query protocol support.

As a first step for this contribution, I updated the versions of `eamark` and `ex_doc` in order to remove warning generated during build. 

I checked the the two generated directory and there is absolutely no difference, so I guess this upgrade does not introduce any regression.

**edit** : I also had to update the .travis.yml in order to fix the build which was returning the following error with previous settings

```
Could not fetch data, please download manually from "https://hex.pm/installs/hex.ez?elixir=1.0.2" and copy it to "/home/travis/.kiex/mix/archives/elixir-1.0.2/hex.ez"
```

Regards.